### PR TITLE
Update CLASSIFIERS with python 3.8 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.5
 Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3 :: Only
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Software Development


### PR DESCRIPTION
There are numpy wheels for python 3.8 on [pypi](https://pypi.org/project/numpy/#files) but this information is not present in CLASSIFIERS parts of setup.py file.

so webpage https://pyreadiness.org/3.8/ report that numpy is not ready for python 3.8
